### PR TITLE
Add project breakdowns for Minimalists and Unicellular

### DIFF
--- a/index.html
+++ b/index.html
@@ -1176,18 +1176,6 @@
                     </div>
                 </div>
             </section>
-            <section id="featured-system" class="reveal">
-                <h2>Featured System</h2>
-                <div class="featured-card">
-                    <a href="minimalists.html">
-                        <img src="Project Media/Minimalists/Thumbnail4.png" alt="Minimalists screenshot" loading="lazy"/>
-                        <div class="featured-info">
-                            <h3>Minimalists – AI &amp; Node Control</h3>
-                            <p>Codebase Breakdown</p>
-                        </div>
-                    </a>
-                </div>
-            </section>
             <section id="skills" class="reveal">
                 <h2>My Skills</h2>
                 <div class="skills-container">
@@ -1268,7 +1256,7 @@
                                 <a href="https://embitgames.itch.io/minimalists" target="_blank" class="itchio"> <img src="itch-icon.webp" alt="Itch.io Icon" onerror="this.style.display='none'" loading="lazy" /> Play in browser </a>
                                 <a class="details" href="minimalists.html">
                                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
-                                    Codebase Breakdown
+                                    Project Breakdown
                                 </a>
                             </div>
                         </div>
@@ -1306,6 +1294,10 @@
                             <div class="project-links">
                                 <a href="https://github.com/EmbitGames/UnicellularRebuiltECS" target="_blank" class="github"> <img src="github-icon.webp" alt="GitHub Icon" onerror="this.style.display='none'" loading="lazy" /> Github </a>
                                 <a href="https://embitgames.itch.io/unicellular" target="_blank" class="itchio"> <img src="itch-icon.webp" alt="Itch.io Icon" onerror="this.style.display='none'" loading="lazy" /> Play in browser </a>
+                                <a class="details" href="unicellular.html">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
+                                    Project Breakdown
+                                </a>
                             </div>
                         </div>
                     </div>
@@ -1430,6 +1422,27 @@
                             </div>
                         </div>
                     </div>
+                </div>
+            </section>
+            <section id="project-breakdowns" class="reveal">
+                <h2>Project Breakdowns</h2>
+                <div class="featured-card">
+                    <a href="minimalists.html">
+                        <img src="Project Media/Minimalists/Thumbnail4.png" alt="Minimalists screenshot" loading="lazy"/>
+                        <div class="featured-info">
+                            <h3>Minimalists – AI &amp; Node Control</h3>
+                            <p>Project Breakdown</p>
+                        </div>
+                    </a>
+                </div>
+                <div class="featured-card">
+                    <a href="unicellular.html">
+                        <img src="Project Media/Unicellular/UnicellInteractionPoster.webp" alt="Unicellular screenshot" loading="lazy"/>
+                        <div class="featured-info">
+                            <h3>Unicellular – Entity Simulation</h3>
+                            <p>Project Breakdown</p>
+                        </div>
+                    </a>
                 </div>
             </section>
             <section id="education" class="reveal">


### PR DESCRIPTION
## Summary
- Rename featured system section to Project Breakdowns and relocate below project listings
- Add Unicellular alongside Minimalists in Project Breakdowns
- Provide Project Breakdown buttons on Minimalists and Unicellular cards