### PR TITLE
Make project breakdown cards a grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -537,11 +537,26 @@
             gap: 1.5rem;
         }
 
-        .featured-card { position: relative; max-width: 500px; margin: 0 auto 2rem; border: 1px solid var(--border-color); border-radius: 8px; overflow: hidden; }
+        .featured-card { position: relative; width: 100%; border: 1px solid var(--border-color); border-radius: 8px; overflow: hidden; }
         .featured-card img { width: 100%; display: block; }
         .featured-info { position: absolute; bottom: 0; left: 0; right: 0; background: rgba(0,0,0,0.6); padding: 1rem; }
         .featured-info h3 { margin: 0; }
         .featured-info p { margin: 0; }
+
+        #project-breakdowns .featured-card p {
+            color: #fff;
+            -webkit-text-fill-color: #fff;
+            background: none;
+            transition: color 0.3s ease, -webkit-text-fill-color 0.3s ease;
+        }
+
+        #project-breakdowns .featured-card:hover p {
+            background: var(--main-gradient);
+            -webkit-background-clip: text;
+            background-clip: text;
+            -webkit-text-fill-color: transparent;
+            color: transparent;
+        }
 
         .project-card {
             background: var(--card-bg);
@@ -1426,23 +1441,25 @@
             </section>
             <section id="project-breakdowns" class="reveal">
                 <h2>Project Breakdowns</h2>
-                <div class="featured-card">
-                    <a href="minimalists.html">
-                        <img src="Project Media/Minimalists/Thumbnail4.png" alt="Minimalists screenshot" loading="lazy"/>
-                        <div class="featured-info">
-                            <h3>Minimalists – AI &amp; Node Control</h3>
-                            <p>Project Breakdown</p>
-                        </div>
-                    </a>
-                </div>
-                <div class="featured-card">
-                    <a href="unicellular.html">
-                        <img src="Project Media/Unicellular/UnicellInteractionPoster.webp" alt="Unicellular screenshot" loading="lazy"/>
-                        <div class="featured-info">
-                            <h3>Unicellular – Entity Simulation</h3>
-                            <p>Project Breakdown</p>
-                        </div>
-                    </a>
+                <div class="project-grid">
+                    <div class="featured-card">
+                        <a href="minimalists.html">
+                            <img src="Project Media/Minimalists/Thumbnail4.png" alt="Minimalists screenshot" loading="lazy"/>
+                            <div class="featured-info">
+                                <h3>Minimalists – AI &amp; Node Control</h3>
+                                <p>Project Breakdown</p>
+                            </div>
+                        </a>
+                    </div>
+                    <div class="featured-card">
+                        <a href="unicellular.html">
+                            <img src="Project Media/Unicellular/UnicellInteractionPoster.webp" alt="Unicellular screenshot" loading="lazy"/>
+                            <div class="featured-info">
+                                <h3>Unicellular – Entity Simulation</h3>
+                                <p>Project Breakdown</p>
+                            </div>
+                        </a>
+                    </div>
                 </div>
             </section>
             <section id="education" class="reveal">


### PR DESCRIPTION
## Summary
- Display project breakdown cards in a responsive grid so Minimalists and Unicellular appear side-by-side on larger screens.
- Style "Project Breakdown" labels with orange-yellow gradient on hover and white when idle across all themes.